### PR TITLE
fix: transform car image fields for frontend compatibility

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,15 +15,31 @@ export default function Home() {
   const [searchTerm, setSearchTerm] = useState("")
   
   useEffect(() => {
-    fetch("https://cbsofttechnology.com.ng/api/get_cars.php")
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.status === "success") {
-          setCarData(data.data)
-        }
-      })
-      .catch((err) => console.error("Error fetching cars:", err))
-  }, [])
+  fetch("https://cbsofttechnology.com.ng/api/get_cars.php")
+    .then((res) => res.json())
+    .then((data) => {
+      console.log("Fetched cars:", data);
+
+      if (data.status === "success" && Array.isArray(data.data)) {
+        const transformedCars = data.data.map((car: any) => ({
+          ...car,
+          images: {
+            front: car.image_front,
+            back: car.image_back,
+            left: car.image_left,
+            right: car.image_right,
+          },
+        }));
+
+        setCarData(transformedCars);
+      } else {
+        console.warn("Unexpected API response:", data);
+      }
+    })
+    .catch((err) => console.error("Error fetching cars:", err));
+}, []);
+
+
   
   
 


### PR DESCRIPTION
This update transforms car image fields from the backend (image_front, image_back, etc.) into the expected images object for frontend rendering. Fixes issue where no cars were displayed.
